### PR TITLE
Updated requirements.txt with Python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Python==2.7.x
 Flask==0.10.1
 itsdangerous==0.24
 Jinja2==2.7.3


### PR DESCRIPTION
Attempting to build with Python 3 will fail and discourage beginners. Added Python requirement to requirements.txt for clarity.
